### PR TITLE
get/set/copy schedules for all device types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Drayton Wiser Hub API v 1.0.8
+# Drayton Wiser Hub API v 1.0.9
 
 This repository contains a simple API which queries the Drayton Wiser Heating sysystem used in the UK.
 
@@ -7,7 +7,7 @@ The API functionality provides the following functionality
 - Ability to query all thermostats and room stats
 - Ability to set temperature of room and TRV thermostats
 - Ability to query various data about the system (like heating status)
-- Ability to query and set schedules for rooms
+- Ability to query and set and copy schedules
 - Ability to query and set smartplugs (modes and states)
 
 The project is closely associated with the Wiser HomeAssitant component availabe here https://github.com/asantaga/wiserHomeAssistantPlatform
@@ -75,4 +75,6 @@ Documentation available in [docs](docs) directory and within comments in the cod
 * Merged [pull17](https://github.com/asantaga/wiserheatingapi/pull/17), Enhancement to detect invalid JSON from the hub, thanks @TobyLL!  fixed bug in getSmartplug state not working correctly
 1.0.8 
 * Merged [pull20(https://github.com/asantaga/wiserheatingapi/pull/20 ) Fix for TRVs not keeping off setting
+1.0.9
+* Ability to get,set and copy schedules for all devices
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="wiser-heating-api",
-    version="1.0.8",
+    version="1.0.9",
     author="Angelo Santagata",
     author_email="angelosantagata@gmail.com",
     description="A simple API for accessing data on the Drayton Wiser Heating system",

--- a/wiserHeatingAPI/wiserHub.py
+++ b/wiserHeatingAPI/wiserHub.py
@@ -38,7 +38,7 @@ TEMP_OFF = -20
 
 TIMEOUT = 10
 
-__VERSION__ = "1.0.8.1"
+__VERSION__ = "1.0.9.0"
 
 """
 Exception Handlers

--- a/wiserHeatingAPI/wiserHub.py
+++ b/wiserHeatingAPI/wiserHub.py
@@ -36,7 +36,7 @@ TEMP_MINIMUM = 5
 TEMP_MAXIMUM = 30
 TEMP_OFF = -20
 
-TIMEOUT = 5
+TIMEOUT = 10
 
 __VERSION__ = "1.0.8.1"
 
@@ -486,32 +486,138 @@ class wiserHub:
             "getRoomStatData for deviceID {} not found due".format(deviceId)
         )
 
+    def getSchedule(self, scheduleId):
+        """
+        Get Schedule by Schedule ID
+        
+        param scheduleId:
+        return: json data
+        """
+        self.checkHubData()
+        for schedule in self.wiserHubData.get("Schedule"):
+                if schedule.get("id") == scheduleId:
+                    return schedule
+        
+        raise WiserNotFound(
+            "Schedule with id {} not found ".format(scheduleId)
+        )
+
+    def setSchedule(self, scheduleId, scheduleData: dict):
+        """
+        Set Schedule by Schedule ID
+        
+        param scheduleId:
+        param scheduleData:
+        return: boolean
+        """
+        self.checkHubData()
+
+        for schedule in self.wiserHubData.get("Schedule"):
+                if schedule.get("id") == scheduleId:
+                    patchData = scheduleData
+                    response = requests.patch(
+                        url=WISERSCHEDULEURL.format(self.hubIP, scheduleId),
+                        headers=self.headers,
+                        json=patchData,
+                        timeout=TIMEOUT,
+                    )
+
+                    if response.status_code != 200:
+                        _LOGGER.debug(
+                            "Set Schedule Response code = {}".format(
+                                response.status_code
+                            )
+                        )
+                        raise WiserRESTException(
+                            "Error setting schedule for id {} , error {} {}".format(
+                                scheduleId, response.status_code, response.text
+                            )
+                        )
+                    else:
+                        return True
+        raise WiserNotFound("No schedule found that matches id")
+
+    def setScheduleFromFile(self, scheduleId, scheduleFile: str):
+        """
+        Sets Schedule from File
+
+        param scheduleId:
+        param scheduleData: json data for schedule
+        return: boolen
+        """
+        for schedule in self.wiserHubData.get("Schedule"):
+                if schedule.get("id") == scheduleId:
+                    if os.path.exists(scheduleFile):
+                        try:
+                            with open(scheduleFile, "r") as f:
+                                scheduleData = json.load(f)
+                        except:
+                            raise Exception(
+                                "Error reading file {}".format(scheduleFile)
+                            )
+
+                        patchData = scheduleData
+                        response = requests.patch(
+                            url=WISERSCHEDULEURL.format(self.hubIP, scheduleId),
+                            headers=self.headers,
+                            json=patchData,
+                            timeout=TIMEOUT,
+                        )
+
+                        if response.status_code != 200:
+                            _LOGGER.debug(
+                                "Set Schedule Response code = {}".format(
+                                    response.status_code
+                                )
+                            )
+                            raise WiserRESTException(
+                                "Error setting schedule {} , error {} {}".format(
+                                    scheduleId, response.status_code, response.text
+                                )
+                            )
+                        else:
+                            return True
+                    else:
+                        raise FileNotFoundError(
+                            "Schedule file, {}, not found.".format(
+                                os.path.abspath(scheduleFile)
+                            )
+                        )
+        raise WiserNotFound("No schedule found that matches Id")
+
+    def copySchedule(self, fromScheduleId, toScheduleId):
+        """
+        Copies schedule from one id to another
+
+        param fromScheduleId:
+        param toScheduleId:
+        return:
+        """
+        scheduleData = self.getSchedule(fromScheduleId)
+
+        if scheduleData is not None:
+            self.setSchedule(toScheduleId, scheduleData)
+        else:
+            raise WiserNotFound(
+                "Error copying schedule.  One of the schedule Ids is not valid"
+            )
+
     def getRoomSchedule(self, roomId):
         """
         Gets Room Schedule Data
-        
         param roomId:
         return: json data
         """
         self.checkHubData()
-
-        if self.getRoom(roomId) is None:
+        try:
+            scheduleId = self.getRoom(roomId).get("ScheduleId",0)
+            if scheduleId > 0:
+                return self.getSchedule(scheduleId)
+        except:
             raise WiserNotFound(
-                "getRoomSchedule for room {} not found ".format(roomId)
+                "Schedule for room {} not found".format(roomId)
             )
 
-        scheduleId = self.getRoom(roomId).get("ScheduleId")
-        if scheduleId is not None:
-            for schedule in self.wiserHubData.get("Schedule"):
-                if schedule.get("id") == scheduleId:
-                    return schedule
-            raise WiserNotFound(
-                "getRoomSchedule for room {} not found ".format(roomId)
-            )
-        else:
-            raise WiserNotFound(
-                "getRoomSchedule for room {} not found ".format(roomId)
-            )
 
     def setRoomSchedule(self, roomId, scheduleData: dict):
         """
@@ -521,28 +627,9 @@ class wiserHub:
         param scheduleData: json data for schedule
         return:
         """
-        scheduleId = self.getRoom(roomId).get("ScheduleId")
-
-        if scheduleId is not None:
-            patchData = scheduleData
-            response = requests.patch(
-                url=WISERSCHEDULEURL.format(self.hubIP, scheduleId),
-                headers=self.headers,
-                json=patchData,
-                timeout=TIMEOUT,
-            )
-
-            if response.status_code != 200:
-                _LOGGER.debug(
-                    "Set Schedule Response code = {}".format(
-                        response.status_code
-                    )
-                )
-                raise WiserRESTException(
-                    "Error setting schedule for room {} , error {} {}".format(
-                        roomId, response.status_code, response.text
-                    )
-                )
+        scheduleId = self.getRoom(roomId).get("ScheduleId",0)
+        if scheduleId > 0:
+            self.setSchedule(scheduleId, scheduleData)
         else:
             raise WiserNotFound("No schedule found that matches roomId")
 
@@ -554,43 +641,10 @@ class wiserHub:
         param scheduleData: json data for schedule
         return:
         """
-        scheduleId = self.getRoom(roomId).get("ScheduleId")
+        scheduleId = self.getRoom(roomId).get("ScheduleId",0)
 
-        if scheduleId is not None:
-            if os.path.exists(scheduleFile):
-                try:
-                    with open(scheduleFile, "r") as f:
-                        scheduleData = json.load(f)
-                except:
-                    raise Exception(
-                        "Error reading file {}".format(scheduleFile)
-                    )
-
-                patchData = scheduleData
-                response = requests.patch(
-                    url=WISERSCHEDULEURL.format(self.hubIP, scheduleId),
-                    headers=self.headers,
-                    json=patchData,
-                    timeout=TIMEOUT,
-                )
-
-                if response.status_code != 200:
-                    _LOGGER.debug(
-                        "Set Schedule Response code = {}".format(
-                            response.status_code
-                        )
-                    )
-                    raise WiserRESTException(
-                        "Error setting schedule for room {} , error {} {}".format(
-                            roomId, response.status_code, response.text
-                        )
-                    )
-            else:
-                raise FileNotFoundError(
-                    "Schedule file, {}, not found.".format(
-                        os.path.abspath(scheduleFile)
-                    )
-                )
+        if scheduleId > 0:
+            self.setScheduleFromFile(scheduleId, scheduleFile)
         else:
             raise WiserNotFound("No schedule found that matches roomId")
 
@@ -602,19 +656,15 @@ class wiserHub:
         param toRoomId:
         return: boolean
         """
-        scheduleData = self.getRoomSchedule(fromRoomId)
-
-        print(json.dumps(scheduleData))
-
-        print("TYPE:{}".format(type(scheduleData)))
-
-        if scheduleData is not None:
-            self.setRoomSchedule(toRoomId, scheduleData)
+        fromScheduleId = self.getRoom(fromRoomId).get("ScheduleId",0)
+        toScheduleId = self.getRoom(toRoomId).get("ScheduleId",0)
+        if fromScheduleId > 0 and toScheduleId > 0:
+            self.copySchedule(fromScheduleId, toScheduleId)
         else:
             raise WiserNotFound(
                 "Error copying schedule.  One of the room Ids is not valid"
             )
-
+ 
     def setHomeAwayMode(self, mode, temperature=10):
         """
         Sets default Home or Away mode, optionally allows you to set a temperature for away mode


### PR DESCRIPTION
Angelo,  this is some changes to the api to allow get/set and copy of schedules by id to support changes in the integration to fix issue #80 - hot water schedule editing support.  It will also work for smartplugs too.

I found a neat way to work with all device types with just the one set of services.  The update for Hass integration is in the dev branch but it needs this version of the api to work.

Should also say that I have left the original setRoomSchedule, getRoomSchedule etc functions in place for backward compatibility.